### PR TITLE
Added a special error for when a device is destroyed.

### DIFF
--- a/device.js
+++ b/device.js
@@ -177,6 +177,11 @@ Device.prototype.call = function(/* type, ...args */) {
     next.apply(next, arguments);
   };
   var handlerArgs = rest.concat([cb]);
+  
+  if(this.state == 'zetta-device-destroy') {
+    return next(new Error('Machine destroyed. Cannot use transition ' + type)); 
+  } 
+
   if (this._transitions[type]) {
     if(this._transitions[type].handler === undefined){
       return next(new Error('Machine does not implement transition '+type));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zetta-device",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Device class for Zetta.",
   "main": "device.js",
   "dependencies": {


### PR DESCRIPTION
- when a device enters the `zetta-device-destroyed` state, and try to execute a transition we give a special error indicating the transition can't be fired.